### PR TITLE
Update objc to modern code style.

### DIFF
--- a/src/compiler/objc_enum_field.cc
+++ b/src/compiler/objc_enum_field.cc
@@ -103,8 +103,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
                        "}\n"
                        "- (void) setHas$capitalized_name$:(BOOL) _value_ {\n"
                        "  has$capitalized_name$_ = !!_value_;\n"
-                       "}\n"
-                       "@synthesize $name$;\n");
+                       "}\n");
     }
     
     
@@ -275,7 +274,6 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
     }
     
     void RepeatedEnumFieldGenerator::GenerateSynthesizeSource(io::Printer* printer) const {
-        printer->Print(variables_, "@synthesize $list_name$;\n");
         printer->Print(variables_, "@dynamic $name$;\n");
     }
     
@@ -322,10 +320,10 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
     void RepeatedEnumFieldGenerator::GenerateMembersSource(io::Printer* printer) const {
         printer->Print(variables_,
                        "- (PBArray *)$name$ {\n"
-                       "  return $list_name$;\n"
+                       "  return _$list_name$;\n"
                        "}\n"
                        "- ($type$)$name$AtIndex:(NSUInteger)index {\n"
-                       "  return ($type$)[$list_name$ enumAtIndex:index];\n"
+                       "  return ($type$)[_$list_name$ enumAtIndex:index];\n"
                        "}\n");
     }
     

--- a/src/compiler/objc_helpers.cc
+++ b/src/compiler/objc_helpers.cc
@@ -488,7 +488,8 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
             ("superclass",          "pb_superclass")
             ("class",               "pb_class")
             ("description",         "pb_description")
-            ("debugDescription",    "pb_debugDescription");
+            ("debugDescription",    "pb_debugDescription")
+            ("public",              "pb_public");
         
         NSObjectMap::const_iterator it = keywords.find(name);
         

--- a/src/compiler/objc_message.cc
+++ b/src/compiler/objc_message.cc
@@ -274,9 +274,6 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
         for (int i = 0; i < descriptor_->field_count(); i++) {
             field_generators_.get(sorted_fields[i]).GenerateHasFieldHeader(printer);
         }
-        for (int i = 0; i < descriptor_->field_count(); i++) {
-            field_generators_.get(sorted_fields[i]).GenerateFieldHeader(printer);
-        }
         printer->Outdent();
         
         printer->Print("}\n");

--- a/src/compiler/objc_message_field.cc
+++ b/src/compiler/objc_message_field.cc
@@ -113,8 +113,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
                        "}\n"
                        "- (void) setHas$capitalized_name$:(BOOL) _value_ {\n"
                        "  has$capitalized_name$_ = !!_value_;\n"
-                       "}\n"
-                       "@synthesize $name$;\n");
+                       "}\n");
     }
     
     
@@ -316,7 +315,6 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
     
     
     void RepeatedMessageFieldGenerator::GenerateSynthesizeSource(io::Printer* printer) const {
-        printer->Print(variables_, "@synthesize $list_name$;\n");
         printer->Print(variables_, "@dynamic $name$;\n");
     }
     
@@ -335,10 +333,10 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
             
             printer->Print(variables_,
                            "- (NSArray *)$name$ {\n"
-                           "  return $list_name$;\n"
+                           "  return _$list_name$;\n"
                            "}\n"
                            "- ($storage_type$)$name$AtIndex:(NSUInteger)index {\n"
-                           "  return [$list_name$ objectAtIndex:index];\n"
+                           "  return [_$list_name$ objectAtIndex:index];\n"
                            "}\n");
             
         }

--- a/src/compiler/objc_primitive_field.cc
+++ b/src/compiler/objc_primitive_field.cc
@@ -257,9 +257,6 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
     void PrimitiveFieldGenerator::GeneratePropertyHeader(io::Printer* printer) const {
         if (IsReferenceType(GetObjectiveCType(descriptor_))) {
             printer->Print(variables_,"@property (readonly, strong)$storage_attribute$ $storage_type$ $name$;\n");
-        } else if (GetObjectiveCType(descriptor_) == OBJECTIVECTYPE_BOOLEAN) {
-            printer->Print(variables_,
-                           "- (BOOL) $name$;\n");
         } else {
             printer->Print(variables_,
                            "@property (readonly) $storage_type$ $name$;\n");
@@ -286,18 +283,6 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
                        "- (void) setHas$capitalized_name$:(BOOL) _value_ {\n"
                        "  has$capitalized_name$_ = !!_value_;\n"
                        "}\n");
-        
-        if (GetObjectiveCType(descriptor_) == OBJECTIVECTYPE_BOOLEAN) {
-            printer->Print(variables_,
-                           "- (BOOL) $name$ {\n"
-                           "  return !!$name$_;\n"
-                           "}\n"
-                           "- (void) set$capitalized_name$:(BOOL) _value_ {\n"
-                           "  $name$_ = !!_value_;\n"
-                           "}\n");
-        } else {
-            printer->Print(variables_, "@synthesize $name$;\n");
-        }
     }
     
     
@@ -495,7 +480,6 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
     
     
     void RepeatedPrimitiveFieldGenerator::GenerateSynthesizeSource(io::Printer* printer) const {
-        printer->Print(variables_, "@synthesize $list_name$;\n");
         printer->Print(variables_, "@dynamic $name$;\n");
     }
     
@@ -555,18 +539,18 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
         if(isObjectArray(descriptor_)){
             printer->Print(variables_,
                            "- (NSArray *)$name$ {\n"
-                           "  return $list_name$;\n"
+                           "  return _$list_name$;\n"
                            "}\n"
                            "- ($storage_type$)$name$AtIndex:(NSUInteger)index {\n"
-                           "  return [$list_name$ objectAtIndex:index];\n"
+                           "  return [_$list_name$ objectAtIndex:index];\n"
                            "}\n");
         }else{
             printer->Print(variables_,
                            "- (PBArray *)$name$ {\n"
-                           "  return $list_name$;\n"
+                           "  return _$list_name$;\n"
                            "}\n"
                            "- ($storage_type$)$name$AtIndex:(NSUInteger)index {\n"
-                           "  return [$list_name$ $array_value_type_name$AtIndex:index];\n"
+                           "  return [_$list_name$ $array_value_type_name$AtIndex:index];\n"
                            "}\n");
         }
     }


### PR DESCRIPTION
Use '_' prefix for property variables.
Rename public keyword to avoid compile failure.